### PR TITLE
Update README.md with new pygments.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ grunt-groc
 
 [![Build Status](https://travis-ci.org/jdcataldo/grunt-groc.png?branch=master)](https://travis-ci.org/jdcataldo/grunt-groc)
 
-Groc depends on [Pygments](http://pygments.org/) to generate documentation. Follow the installation instructions [here](http://pygments.org/docs/installation/).
+Groc depends on [Pygments](http://pygments.org/) to generate documentation. Follow the installation instructions [here](http://pygments.org/download/).
 
 
 ### Usage


### PR DESCRIPTION
/docs/installation/ no longer exists, /download/ seems to be the next best thing.
