### PR TITLE
Update peerDependency to allow use of latest version of Grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-jshint": "~0.6.4"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies